### PR TITLE
Fix read_data_package_archive() and friends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: A client for the Environmental Data Initiative repository REST API.
 Imports: curl, httr, jsonlite, xml2
 License: MIT + file LICENSE
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Suggests: knitr, readr, vcr, rmarkdown, roxygen2, testthat
 URL: https://github.com/ropensci/EDIutils, https://docs.ropensci.org/EDIutils/
 BugReports: https://github.com/ropensci/EDIutils/issues

--- a/R/create_data_package_archive.R
+++ b/R/create_data_package_archive.R
@@ -1,40 +1,19 @@
 #' Create data package archive (zip)
+#' 
+#' This function is DEPRECATED.
 #'
 #' @param packageId (character) Data package identifier
 #' @param env (character) Repository environment. Can be: "production",
 #' "staging", or "development".
 #'
-#' @return transaction (character) Transaction identifier. May be used in a
-#' subsequent call to:
-#' \itemize{
-#'   \item \code{read_data_package_error()} to determine the operation status
-#'   \item \code{read_data_package_archive()} to obtain the Zip archive
-#' }
+#' @return transaction (character) Transaction identifier.
 #' 
 #' @family Miscellaneous
 #'
 #' @export
 #'
-#' @examples
-#' \dontrun{
-#'
-#' # Create zip archive
-#' packageId <- "knb-lter-sev.31999.1"
-#' transaction <- create_data_package_archive(packageId)
-#' transaction
-#' #> [1] "archive_knb-lter-sev.31999.1_16396683904724129"
-#'
-#' # Check creation status
-#' read_data_package_error(transaction)
-#'
-#' # Download zip archive
-#' read_data_package_archive(packageId, transaction, path = tempdir())
-#' #> |=============================================================| 100%
-#' dir(tempdir())
-#' #> [1] "knb-lter-sev.31999.1.zip"
-#' }
-#'
 create_data_package_archive <- function(packageId, env = "production") {
+  .Deprecated(msg = "The 'create_data_package_archive' function is deprecated.")
   url <- paste0(
     base_url(env), "/package/archive/eml/",
     paste(parse_packageId(packageId), collapse = "/")

--- a/R/read_data_package_archive.R
+++ b/R/read_data_package_archive.R
@@ -1,7 +1,8 @@
 #' Read data package archive
 #'
 #' @param packageId (character) Data package identifier
-#' @param transaction (character) Transaction identifier
+#' @param transaction (character) Transaction identifier. This parameter is 
+#' DEPRECATED.
 #' @param path (character) Path of directory in which the result will be written
 #' @param env (character) Repository environment. Can be: "production",
 #' "staging", or "development".
@@ -16,17 +17,8 @@
 #' @examples
 #' \dontrun{
 #'
-#' # Create zip archive
-#' packageId <- "knb-lter-sev.31999.1"
-#' transaction <- create_data_package_archive(packageId)
-#' transaction
-#' #> [1] "archive_knb-lter-sev.31999.1_16396683904724129"
-#'
-#' # Check creation status
-#' read_data_package_error(transaction)
-#'
 #' # Download zip archive
-#' read_data_package_archive(packageId, transaction, path = tempdir())
+#' read_data_package_archive("knb-lter-sev.31999.1", path = tempdir())
 #' #> |=============================================================| 100%
 #' dir(tempdir())
 #' #> [1] "knb-lter-sev.31999.1.zip"
@@ -36,10 +28,15 @@ read_data_package_archive <- function(packageId,
                                       transaction,
                                       path,
                                       env = "production") {
+  if (!missing(transaction)) {
+    warning(
+      "The 'transaction' parameter is deprecated and no longer required. ",
+      "Please use this function without it.", call. = FALSE
+    )
+  }
   url <- paste0(
-    base_url(env), "/package/archive/eml/",
-    paste(parse_packageId(packageId), collapse = "/"), "/",
-    transaction
+    base_url(env), "/package/download/eml/",
+    paste(parse_packageId(packageId), collapse = "/")
   )
   resp <- httr::GET(
     url,

--- a/R/read_data_package_error.R
+++ b/R/read_data_package_error.R
@@ -14,25 +14,6 @@
 #'
 #' @export
 #'
-#' @examples
-#' \dontrun{
-#'
-#' # Create zip archive
-#' packageId <- "knb-lter-sev.31999.1"
-#' transaction <- create_data_package_archive(packageId)
-#' transaction
-#' #> [1] "archive_knb-lter-sev.31999.1_16396683904724129"
-#'
-#' # Check creation status
-#' read_data_package_error(transaction)
-#'
-#' # Download zip archive
-#' read_data_package_archive(packageId, transaction, path = tempdir())
-#' #> |=============================================================| 100%
-#' dir(tempdir())
-#' #> [1] "knb-lter-sev.31999.1.zip"
-#' }
-#'
 read_data_package_error <- function(transaction, env = "production") {
   if (grepl("__", transaction)) {
     transaction <- unlist(strsplit(transaction, "__"))[1]

--- a/man/create_data_package_archive.Rd
+++ b/man/create_data_package_archive.Rd
@@ -13,35 +13,10 @@ create_data_package_archive(packageId, env = "production")
 "staging", or "development".}
 }
 \value{
-transaction (character) Transaction identifier. May be used in a
-subsequent call to:
-\itemize{
-  \item \code{read_data_package_error()} to determine the operation status
-  \item \code{read_data_package_archive()} to obtain the Zip archive
-}
+transaction (character) Transaction identifier.
 }
 \description{
-Create data package archive (zip)
-}
-\examples{
-\dontrun{
-
-# Create zip archive
-packageId <- "knb-lter-sev.31999.1"
-transaction <- create_data_package_archive(packageId)
-transaction
-#> [1] "archive_knb-lter-sev.31999.1_16396683904724129"
-
-# Check creation status
-read_data_package_error(transaction)
-
-# Download zip archive
-read_data_package_archive(packageId, transaction, path = tempdir())
-#> |=============================================================| 100\%
-dir(tempdir())
-#> [1] "knb-lter-sev.31999.1.zip"
-}
-
+This function is DEPRECATED.
 }
 \seealso{
 Other Miscellaneous: 

--- a/man/read_data_package_archive.Rd
+++ b/man/read_data_package_archive.Rd
@@ -9,7 +9,8 @@ read_data_package_archive(packageId, transaction, path, env = "production")
 \arguments{
 \item{packageId}{(character) Data package identifier}
 
-\item{transaction}{(character) Transaction identifier}
+\item{transaction}{(character) Transaction identifier. This parameter is 
+DEPRECATED.}
 
 \item{path}{(character) Path of directory in which the result will be written}
 
@@ -26,17 +27,8 @@ Read data package archive
 \examples{
 \dontrun{
 
-# Create zip archive
-packageId <- "knb-lter-sev.31999.1"
-transaction <- create_data_package_archive(packageId)
-transaction
-#> [1] "archive_knb-lter-sev.31999.1_16396683904724129"
-
-# Check creation status
-read_data_package_error(transaction)
-
 # Download zip archive
-read_data_package_archive(packageId, transaction, path = tempdir())
+read_data_package_archive("knb-lter-sev.31999.1", path = tempdir())
 #> |=============================================================| 100\%
 dir(tempdir())
 #> [1] "knb-lter-sev.31999.1.zip"

--- a/man/read_data_package_error.Rd
+++ b/man/read_data_package_error.Rd
@@ -23,26 +23,6 @@ Read data package error
 \note{
 User authentication is required (see \code{login()})
 }
-\examples{
-\dontrun{
-
-# Create zip archive
-packageId <- "knb-lter-sev.31999.1"
-transaction <- create_data_package_archive(packageId)
-transaction
-#> [1] "archive_knb-lter-sev.31999.1_16396683904724129"
-
-# Check creation status
-read_data_package_error(transaction)
-
-# Download zip archive
-read_data_package_archive(packageId, transaction, path = tempdir())
-#> |=============================================================| 100\%
-dir(tempdir())
-#> [1] "knb-lter-sev.31999.1.zip"
-}
-
-}
 \seealso{
 Other Accessing: 
 \code{\link{read_data_entity_checksum}()},

--- a/tests/testthat/test_create_data_package_archive.R
+++ b/tests/testthat/test_create_data_package_archive.R
@@ -4,18 +4,19 @@ testthat::test_that("create_data_package_archive() works (mock test)", {
   vcr::skip_if_vcr_off()
   vcr::use_cassette("create_data_package_archive", {
     packageId <- "knb-lter-sev.31999.1"
-    transaction <- create_data_package_archive(packageId)
+    transaction <- suppressWarnings(
+      create_data_package_archive(packageId)
+    )
   })
   expect_true(class(transaction) == "character")
 })
 
-testthat::test_that("create_data_package_archive() works", {
+testthat::test_that("create_data_package_archive() issues warning", {
+  # Test that the create_data_package_archive() function issues a deprecation 
+  # warning when called.
   skip_if_logged_out()
-  # Create zip archive
-  packageId <- "knb-lter-sev.31999.1"
-  transaction <- create_data_package_archive(packageId)
-  # Download zip archive
-  read_data_package_archive(packageId, transaction, path = tempdir())
-  archive <- paste0(packageId, ".zip")
-  expect_true(archive %in% dir(tempdir()))
+  testthat::expect_warning(
+    object = create_data_package_archive("knb-lter-sev.31999.1"),
+    regexp = "The 'create_data_package_archive' function is deprecated."
+  )
 })

--- a/tests/testthat/test_read_data_package_archive.R
+++ b/tests/testthat/test_read_data_package_archive.R
@@ -3,7 +3,6 @@ context("Read data package archive")
 testthat::test_that("read_data_package_archive() issues deprecation warning", {
   # Test that the read_data_package_archive() function issues a deprecation 
   # warning when the transaction parameter is used.
-  skip_if_logged_out()
   testthat::expect_warning(
     object = read_data_package_archive(
       packageId = "knb-lter-cdr.444.8", 
@@ -36,7 +35,6 @@ testthat::test_that("read_data_package_archive() works with transaction", {
 testthat::test_that("read_data_package_archive() works without transaction", {
   # Test that the read_data_package_archive() function works when the 
   # transaction argument is not used.
-  skip_if_logged_out()
   suppressWarnings(
     read_data_package_archive(
       packageId = "knb-lter-cdr.444.8", 

--- a/tests/testthat/test_read_data_package_archive.R
+++ b/tests/testthat/test_read_data_package_archive.R
@@ -1,5 +1,49 @@
 context("Read data package archive")
 
-testthat::test_that("read_data_package_archive() works", {
-  # Tested in test_create_data_package_archive.R
+testthat::test_that("read_data_package_archive() issues deprecation warning", {
+  # Test that the read_data_package_archive() function issues a deprecation 
+  # warning when the transaction parameter is used.
+  skip_if_logged_out()
+  testthat::expect_warning(
+    object = read_data_package_archive(
+      packageId = "knb-lter-cdr.444.8", 
+      transaction = "archive_knb-lter-cdf.444.8_16396683904724129", 
+      path = tempdir()),
+    regexp = "The 'transaction' parameter is deprecated"
+  )
+  archive <- "knb-lter-cdr.444.8.zip"
+  file.remove(paste0(tempdir(), "/", archive))
+})
+
+
+testthat::test_that("read_data_package_archive() works with transaction", {
+  # Test that the read_data_package_archive() function works when the 
+  # transaction argument is used.
+  skip_if_logged_out()
+  suppressWarnings(
+    read_data_package_archive(
+      packageId = "knb-lter-cdr.444.8", 
+      transaction = "archive_knb-lter-cdf.444.8_16396683904724129", 
+      path = tempdir()
+    )
+  )
+  archive <- "knb-lter-cdr.444.8.zip"
+  expect_true(archive %in% dir(tempdir()))
+  file.remove(paste0(tempdir(), "/", archive))
+})
+
+
+testthat::test_that("read_data_package_archive() works without transaction", {
+  # Test that the read_data_package_archive() function works when the 
+  # transaction argument is not used.
+  skip_if_logged_out()
+  suppressWarnings(
+    read_data_package_archive(
+      packageId = "knb-lter-cdr.444.8", 
+      path = tempdir()
+    )
+  )
+  archive <- "knb-lter-cdr.444.8.zip"
+  expect_true(archive %in% dir(tempdir()))
+  file.remove(paste0(tempdir(), "/", archive))
 })

--- a/vignettes/search_and_access.Rmd
+++ b/vignettes/search_and_access.Rmd
@@ -94,16 +94,8 @@ packageId <- "edi.1047.1"
 Downloading a data package archive (.zip) requires a data package ID.
 
 ```{r eval=FALSE}
-# Request a zip archive
-transaction <- create_data_package_archive(packageId)
-transaction
-#> [1] "archive_edi.1047.1_14896683904724129"
-
-# Check status of the request (no response indicates success)
-read_data_package_error(transaction)
-
-# Download to path
-read_data_package_archive(packageId, transaction, path = tempdir())
+# Download data package to path
+read_data_package_archive(packageId, path = tempdir())
 #> |=============================================================| 100%
 dir(tempdir())
 #> [1] ""edi.1047.1.zip"


### PR DESCRIPTION
- Correct read_data_package_archive() to align with the updated PASTA API endpoint that supports streaming .zip downloads.
- Deprecate the no-longer-used 'transaction' parameter and the now-obsolete create_data_package_archive() function, which previously returned the 'transaction' value.
- Preserve read_data_package_error() for internal use in check_status_create(), check_status_evaluate(), and check_status_update(), while retaining it as a public function for user customizations.
- Update documentation and vignettes to reflect these changes.

Note: These changes are backwards compatible, and appropriate deprecation warnings will be issued

This fix is related to
PASTAplus/PASTA@03fe3650261477b19a5df299bc3552eb3d2ce036

Fixes #47