### PR TITLE
Update EDI contact email

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -57,7 +57,7 @@ The unit of publication is the data package. It contains one or more data entiti
 
 Authentication is required by data evaluation and upload functions, and to 
 access user audit logs and services. Contact EDI for an account 
-<support@environmentaldatainitiative.org>. Authenticate with `login()` 
+<support@edirepository.org>. Authenticate with `login()` 
 function.
 
 ### Search and Access Data
@@ -125,7 +125,7 @@ data
 
 ### Evaluate and Upload Data
 
-The EDI data repository has a "[staging](https://portal-s.edirepository.org/nis/home.jsp)" environment to test the upload and rendering of new data packages before publishing to "[production](https://portal.edirepository.org/nis/home.jsp)". Authentication is required by functions involving data evaluation and upload. Request an account from support@environmentaldatainitiative.org.
+The EDI data repository has a "[staging](https://portal-s.edirepository.org/nis/home.jsp)" environment to test the upload and rendering of new data packages before publishing to "[production](https://portal.edirepository.org/nis/home.jsp)". Authentication is required by functions involving data evaluation and upload. Request an account from support@edirepository.org.
 
 ```{r eval=FALSE}
 # Authenticate

--- a/vignettes/evaluate_and_upload.Rmd
+++ b/vignettes/evaluate_and_upload.Rmd
@@ -24,7 +24,7 @@ Evaluation and upload to the repository requires data entities are described wit
 
 ## Authenticate
 
-Authentication is required by functions involving data evaluation and upload, audit report access, event notifications, and other account based features. Request an account from support@environmentaldatainitiative.org. There are three options for authenticating:
+Authentication is required by functions involving data evaluation and upload, audit report access, event notifications, and other account based features. Request an account from support@edirepository.org. There are three options for authenticating:
 
 ```{r eval=FALSE}
 # Interactively at the console
@@ -164,7 +164,7 @@ The Dataset and Entity Reports share the same layout:
 * Suggestion - Potential data package improvements to implement to pass the quality check
 * Reference - Source of the rationale for the quality check or where to find more information
 
-Parse through the document and address any errors or warnings (denoted by the Error and Warn labels). To understand why a quality check failed, first read the Name and Description of the quality check to determine what was being tested and how the test was being conducted. Then, compare the Expected result to what was Found. If it is still not clear what caused the failure, try to gain additional insight from the Explanation, Suggestion, and Reference fields, or contact the EDI Data Curation Team for clarification (info@environmentaldatainitiative.org).
+Parse through the document and address any errors or warnings (denoted by the Error and Warn labels). To understand why a quality check failed, first read the Name and Description of the quality check to determine what was being tested and how the test was being conducted. Then, compare the Expected result to what was Found. If it is still not clear what caused the failure, try to gain additional insight from the Explanation, Suggestion, and Reference fields, or contact the EDI Data Curation Team for clarification (info@edirepository.org).
 
 ## Upload
 

--- a/vignettes/tests_requiring_authentication.Rmd
+++ b/vignettes/tests_requiring_authentication.Rmd
@@ -17,7 +17,7 @@ library(EDIutils)
 
 ## Get an EDI User Account
 
-Request accounts via info@environmentaldatainitiative.org
+Request accounts via info@edirepository.org
 
 ## Use the "staging" Environment!
 The EDI repository "staging" environment is a sandbox for testing data package rendering, etc. Do not use the "production" environment for testing. The "production" environment is where publication quality data are released.


### PR DESCRIPTION
Update the EDI contact email address from the deprecated domain @environmentaldatainitaitive.org to the new domain @edirepository.org.

Fixes #51