### PR TITLE
Test 'get_audit_record()' with dynamic 'oid'

### DIFF
--- a/tests/testthat/test_get_audit_record.R
+++ b/tests/testthat/test_get_audit_record.R
@@ -2,7 +2,8 @@ context("Get audit record")
 
 testthat::test_that("get_audit_record() works (real call)", {
   skip_if_logged_out()
-  oid <- "121606334"
+  uploads <- get_recent_uploads(query = "serviceMethod=createDataPackage&limit=1")
+  oid <- uploads$oid
   auditReport <- get_audit_record(oid, as = "xml")
   res <- xml2::xml_find_first(auditReport, ".//auditRecord")
   children_found <- xml2::xml_name(xml2::xml_children(res))


### PR DESCRIPTION
When testing the 'get_audit_record()' function, obtain a fresh 'oid' value from the staging environment. This approach prevents issues with using a static 'oid' value that may become outdated when the staging environment is periodically reset to clear disk space.