### PR TITLE
Skip actual API calls on CRAN

### DIFF
--- a/tests/testthat/test_read_data_package_archive.R
+++ b/tests/testthat/test_read_data_package_archive.R
@@ -3,6 +3,7 @@ context("Read data package archive")
 testthat::test_that("read_data_package_archive() issues deprecation warning", {
   # Test that the read_data_package_archive() function issues a deprecation 
   # warning when the transaction parameter is used.
+  testthat::skip_on_cran()
   testthat::expect_warning(
     object = read_data_package_archive(
       packageId = "knb-lter-cdr.444.8", 
@@ -18,7 +19,7 @@ testthat::test_that("read_data_package_archive() issues deprecation warning", {
 testthat::test_that("read_data_package_archive() works with transaction", {
   # Test that the read_data_package_archive() function works when the 
   # transaction argument is used.
-  skip_if_logged_out()
+  testthat::skip_on_cran()
   suppressWarnings(
     read_data_package_archive(
       packageId = "knb-lter-cdr.444.8", 
@@ -35,6 +36,7 @@ testthat::test_that("read_data_package_archive() works with transaction", {
 testthat::test_that("read_data_package_archive() works without transaction", {
   # Test that the read_data_package_archive() function works when the 
   # transaction argument is not used.
+  testthat::skip_on_cran()
   suppressWarnings(
     read_data_package_archive(
       packageId = "knb-lter-cdr.444.8", 


### PR DESCRIPTION
To prevent CRAN checks from failing and the package from being removed due to potential API issues, skip real API calls in the tests of 'read_data_package_archive()'.